### PR TITLE
rename package to graphql-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# wazo-python-graphql-server-core-packaging
+# wazo-python-graphql-server-packaging
 
-Debian packaging for [python3-graphql-server-core](https://github.com/graphql-python/graphql-server-core/) used in Wazo.
+Debian packaging for [python3-graphql-server](https://github.com/graphql-python/graphql-server/) used in Wazo.
 
 ## Upgrading
 
-To upgrade python-graphql-server-core
+To upgrade python-graphql-server
 
 * Update the version number in the `VERSION` file
 * Update the changelog using `dch -i` to the matching version

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wazo-python-graphql-server-packaging (1.2.0-1~wazo3) wazo-dev-buster; urgency=medium
+
+  * Rename graphql-server
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 13 Feb 2023 11:48:27 -0500
+
 wazo-python-graphql-server-core-packaging (1.2.0-1~wazo2) wazo-dev-buster; urgency=medium
 
   * Use debhelper 12

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: wazo-python-graphql-server-core-packaging
+Source: wazo-python-graphql-server-packaging
 Section: python
 Priority: optional
 Maintainer: Wazo Maintainers <dev+pkg@wazo.community>
@@ -9,12 +9,15 @@ Build-Depends: debhelper (>= 12),
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.7
 
-Package: python3-graphql-server-core
+Package: python3-graphql-server
 Architecture: all
+Provides: python3-graphql-server-core
+Conflicts: python3-graphql-server-core
+Replaces: python3-graphql-server-core
 Depends: ${misc:Depends},
          ${python3:Depends}
-Description: GraphQL server core for Python
- GraphQL-Server-Core is a base library that serves as a helper for building
+Description: GraphQL server for Python
+ GraphQL-Server is a base library that serves as a helper for building
  GraphQL servers or integrations into existing web frameworks using
  GraphQL-Core.
  .

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,11 +1,11 @@
-Format: http://www.debian.org/doc/packaging-manuals/Copyright 1-2020 The Wazo Authors  (see the AUTHORS file)
-Upstream-Name: graphql-server-core
-Source: https://github.com/graphql-python/graphql-server-core
+Format: http://dep.debian.net/deps/dep5
+Upstream-Name: graphql-server
+Source: https://github.com/graphql-python/graphql-server
 
 Files: *
 Copyright: 2017-Present Syrus Akbary
 License: MIT
 
 Files: debian/*
-Copyright: 2020 The Wazo Authors  (see the AUTHORS file)
+Copyright: 2023 The Wazo Authors  (see the AUTHORS file)
 License: GPL-3

--- a/debian/rules
+++ b/debian/rules
@@ -2,8 +2,8 @@
 
 PKG = $(word 2,$(shell dpkg-parsechangelog | grep Source))
 VERSION ?= $(shell cat VERSION)
-URL_DOWNLOAD = "https://github.com/graphql-python/graphql-server-core/archive/v${VERSION}.tar.gz"
-export PYBUILD_NAME=graphql-server-core
+URL_DOWNLOAD = "https://github.com/graphql-python/graphql-server/archive/v${VERSION}.tar.gz"
+export PYBUILD_NAME=graphql-server
 export PYBUILD_DISABLE=test
 export PYBUILD_SYSTEM=distutils
 


### PR DESCRIPTION
why: because upstream version has renamed it to graphql-server and it
was impossible to rebuild package